### PR TITLE
Fixed Indexing of database values

### DIFF
--- a/src/np_utils/stim_scan.py
+++ b/src/np_utils/stim_scan.py
@@ -542,7 +542,7 @@ class StimScan:
             spikes = events[events["channel"] == electrode]["Time"]
             ax.eventplot(
                 spikes,
-                lineoffsets=i,
+                lineoffsets=electrode - min(self.scan_chanels),
                 linelengths=0.5,
                 color="blue",
             )


### PR DESCRIPTION
There was a mismatch between channel values pulled from database and its respective raster plot.

`i` is used as an offset incorrectly in the raster plot where the absolute channel index should have been used instead.